### PR TITLE
refactor: remove `guildOnly` property

### DIFF
--- a/src/bot/commands/Configuration/_config_suggestions.ts
+++ b/src/bot/commands/Configuration/_config_suggestions.ts
@@ -14,8 +14,7 @@ export default class SuggestionsSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Configuration/config.ts
+++ b/src/bot/commands/Configuration/config.ts
@@ -10,8 +10,7 @@ export default class ConfigCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_bot_invite.ts
+++ b/src/bot/commands/Information/_bot_invite.ts
@@ -8,8 +8,7 @@ export default class BotInviteSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Information/_bot_vote.ts
+++ b/src/bot/commands/Information/_bot_vote.ts
@@ -8,8 +8,7 @@ export default class BotVoteSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Information/_server_banner.ts
+++ b/src/bot/commands/Information/_server_banner.ts
@@ -9,8 +9,7 @@ export default class ServerBannerSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_server_icon.ts
+++ b/src/bot/commands/Information/_server_icon.ts
@@ -9,8 +9,7 @@ export default class ServerIconSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_server_info.ts
+++ b/src/bot/commands/Information/_server_info.ts
@@ -9,8 +9,7 @@ export default class ServerInfoSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_user_avatar.ts
+++ b/src/bot/commands/Information/_user_avatar.ts
@@ -9,8 +9,7 @@ export default class UserAvatarSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_user_banner.ts
+++ b/src/bot/commands/Information/_user_banner.ts
@@ -9,8 +9,7 @@ export default class UserBannerSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/_user_info.ts
+++ b/src/bot/commands/Information/_user_info.ts
@@ -9,8 +9,7 @@ export default class UserInfoSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/bot.ts
+++ b/src/bot/commands/Information/bot.ts
@@ -9,8 +9,7 @@ export default class BotCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Information/data/bot.ts
+++ b/src/bot/commands/Information/data/bot.ts
@@ -8,6 +8,7 @@ export default class BotData extends CommandDataStructure {
     this.data = {
       name: 'bot',
       type: ApplicationCommandType.ChatInput,
+      dmPermission: true,
       description: client.languages.manager.get('en_US', 'commandDescriptions:bot'),
       descriptionLocalizations: {
         'pt-BR': client.languages.manager.get('pt_BR', 'commandDescriptions:bot')

--- a/src/bot/commands/Information/server.ts
+++ b/src/bot/commands/Information/server.ts
@@ -10,8 +10,7 @@ export default class ServerCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Information/user.ts
+++ b/src/bot/commands/Information/user.ts
@@ -10,8 +10,7 @@ export default class UserCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: false
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Moderation/poll.ts
+++ b/src/bot/commands/Moderation/poll.ts
@@ -22,8 +22,7 @@ export default class PollCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Text/_text_claps.ts
+++ b/src/bot/commands/Text/_text_claps.ts
@@ -8,8 +8,7 @@ export default class TextClapsSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Text/_text_emojify.ts
+++ b/src/bot/commands/Text/_text_emojify.ts
@@ -55,8 +55,7 @@ export default class TextEmojifySubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Text/_text_invert.ts
+++ b/src/bot/commands/Text/_text_invert.ts
@@ -8,8 +8,7 @@ export default class TextInvertSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Text/_text_vaporwave.ts
+++ b/src/bot/commands/Text/_text_vaporwave.ts
@@ -8,8 +8,7 @@ export default class TextVaporwaveSubCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: false,
-      guildOnly: true
+      showInHelp: false
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Text/text.ts
+++ b/src/bot/commands/Text/text.ts
@@ -9,8 +9,7 @@ export default class TextCommand extends Command {
     this.config = {
       autoDefer: false,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: false
+      showInHelp: true
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Utils/afk.ts
+++ b/src/bot/commands/Utils/afk.ts
@@ -10,8 +10,7 @@ export default class PingCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: false
+      showInHelp: true
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Utils/help.ts
+++ b/src/bot/commands/Utils/help.ts
@@ -11,8 +11,7 @@ export default class HelpCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: false
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/commands/Utils/ping.ts
+++ b/src/bot/commands/Utils/ping.ts
@@ -9,8 +9,7 @@ export default class PingCommand extends Command {
     this.config = {
       autoDefer: true,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: false
+      showInHelp: true
     };
     this.permissions = { bot: [] };
   }

--- a/src/bot/commands/Utils/suggestion.ts
+++ b/src/bot/commands/Utils/suggestion.ts
@@ -41,8 +41,7 @@ export default class PingCommand extends Command {
     this.config = {
       autoDefer: false,
       ephemeral: false,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
     this.permissions = { bot: [PermissionFlagsBits.EmbedLinks] };
   }

--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -24,11 +24,6 @@ export default class InteractionCreateEvent extends Event {
       return client.languages.manager.get(userLocale, path, ...args);
     };
 
-    if (!interaction.inGuild() && botCommand.config.guildOnly) {
-      interaction.reply({ content: `❌ ${interaction.user} **|** ${t('command:errors/commandGuildOnly')}`, ephemeral: true });
-      return;
-    }
-
     if (interaction.inGuild()) {
       if (!InteractionCreateEvent.checkBotPermissions(interaction, botCommand, t)) return;
     }

--- a/src/locales/command/en_US/index.ts
+++ b/src/locales/command/en_US/index.ts
@@ -4,7 +4,6 @@ export default {
   // General errors
   'permissions/bot/missing': (perms: string) => `I don't have the required permissions: ${perms}`,
   'permissions/user/missing': (perms: string) => `You don't have the required permissions: ${perms}`,
-  'errors/commandGuildOnly': 'This command can only be used in servers.',
 
   // Ping
   'ping/calculating': 'Calculating...',

--- a/src/locales/command/pt_BR/index.ts
+++ b/src/locales/command/pt_BR/index.ts
@@ -4,7 +4,6 @@ export default {
   // General errors
   'permissions/bot/missing': (perms: string) => `Eu não tenho as permissões necessárias: \`${perms}\``,
   'permissions/user/missing': (perms: string) => `Você não tem as permissões necessárias: \`${perms}\``,
-  'errors/commandGuildOnly': 'Este comando só pode ser executado em servidores.',
 
   // Ping
   'ping/calculating': 'Calculando...',

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -24,8 +24,6 @@ class Command {
     autoDefer: boolean;
     /** Whether this command should be hidden from the help command */
     showInHelp: boolean;
-    /** Whether this command should only be available in guilds */
-    guildOnly: boolean;
   };
 
   /** Command options to be posted to Discord */
@@ -42,8 +40,7 @@ class Command {
     this.config = {
       ephemeral: false,
       autoDefer: true,
-      showInHelp: true,
-      guildOnly: true
+      showInHelp: true
     };
   }
 


### PR DESCRIPTION
To make commands guild only now, you should include the property `dmPermission: false` on command data.