### PR TITLE
refactor: improve locale types/errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tslib": "2.4.0",
     "tweetnacl": "1.0.3",
     "undici": "5.6.1",
+    "utility-types": "^3.10.0",
     "winston": "3.8.1",
     "winston-transport": "4.5.0"
   }

--- a/src/bot/events/interactionCreate.ts
+++ b/src/bot/events/interactionCreate.ts
@@ -2,7 +2,6 @@ import { ChannelType, ChatInputCommandInteraction, EmbedBuilder, Interaction, Pe
 import type { Command, CommandLocale, CommandRunOptions } from '../../structures/Command';
 import { Event } from '../../structures/Event';
 import type { DenkyClient } from '../../types/Client';
-import type { AllLocalePaths } from '../managers/LanguageManager';
 
 export default class InteractionCreateEvent extends Event {
   /** Webhook used to log commands */
@@ -20,7 +19,7 @@ export default class InteractionCreateEvent extends Event {
 
     const userLocale = client.helpers.recommendLocale(interaction.locale);
 
-    const t = (path: AllLocalePaths, ...args: unknown[]) => {
+    const t = (path: any, ...args: any) => {
       return client.languages.manager.get(userLocale, path, ...args);
     };
 

--- a/src/bot/events/messageCreate.ts
+++ b/src/bot/events/messageCreate.ts
@@ -34,7 +34,7 @@ export default class MessageCreateEvent extends Event {
   async verifyAFKMention(client: DenkyClient, message: Message) {
     if (message.mentions.users.size === 0) return;
 
-    const t = (path: AllLocalePaths, ...args: unknown[]) => {
+    const t = (path: string, ...args: unknown[]) => {
       return client.languages.manager.get(client.helpers.recommendLocale(message.guild?.preferredLocale), path, ...args);
     };
 

--- a/src/bot/managers/LanguageManager.ts
+++ b/src/bot/managers/LanguageManager.ts
@@ -1,15 +1,22 @@
 /* eslint-disable no-await-in-loop */
 import { readdir } from 'node:fs/promises';
+import type { FunctionKeys, NonFunctionKeys } from 'utility-types';
 import type { DenkyClient } from '../../types/Client';
 
 export type LocaleCategories = 'command' | 'commandNames' | 'commandDescriptions' | 'commandCategories';
 export type SupportedLocales = 'en_US' | 'pt_BR';
 
-export type CommandLocaleKeys = keyof typeof import('../../locales/command/pt_BR/index').default;
-export type CommandNamesKeys = keyof typeof import('../../locales/commandNames/pt_BR/index').default;
-export type CommandDescriptionsKeys = keyof typeof import('../../locales/commandDescriptions/pt_BR/index').default;
-export type CommandCategoriesKeys = keyof typeof import('../../locales/commandCategories/pt_BR/index').default;
-export type PermissionLocaleKeys = keyof typeof import('../../locales/permissions/pt_BR/index').default;
+export type CommandLocaleKeysObject = typeof import('../../locales/command/pt_BR/index').default;
+type CommandNamesKeysObject = typeof import('../../locales/commandNames/pt_BR/index').default;
+type CommandDescriptionsKeysObject = typeof import('../../locales/commandDescriptions/pt_BR/index').default;
+type CommandCategoriesKeysObject = typeof import('../../locales/commandCategories/pt_BR/index').default;
+type PermissionLocaleKeysObject = typeof import('../../locales/permissions/pt_BR/index').default;
+
+export type CommandLocaleKeys = keyof CommandLocaleKeysObject;
+export type CommandNamesKeys = keyof CommandNamesKeysObject;
+export type CommandDescriptionsKeys = keyof CommandDescriptionsKeysObject;
+export type CommandCategoriesKeys = keyof CommandCategoriesKeysObject;
+export type PermissionLocaleKeys = keyof PermissionLocaleKeysObject;
 
 export type AllLocaleKeys = CommandLocaleKeys | CommandNamesKeys | CommandDescriptionsKeys | CommandCategoriesKeys | PermissionLocaleKeys;
 export type AllLocalePaths =
@@ -18,6 +25,8 @@ export type AllLocalePaths =
   | `commandCategories:${CommandCategoriesKeys}`
   | `commandNames:${CommandNamesKeys}`
   | `permissions:${PermissionLocaleKeys}`;
+
+export type CommandLocaleKeysObjectGeneric<K extends FunctionKeys<CommandLocaleKeysObject>> = CommandLocaleKeysObject[K];
 
 export class LanguageManager {
   /** The client that instantiated this manager */
@@ -44,7 +53,13 @@ export class LanguageManager {
     }
   }
 
-  get(lang: SupportedLocales, path: AllLocalePaths, ...args: unknown[]) {
+  get<K extends FunctionKeys<CommandLocaleKeysObject>>(locale: SupportedLocales, path: `command:${K}`, ...rest: Parameters<CommandLocaleKeysObjectGeneric<K>>): string;
+  get<K extends NonFunctionKeys<CommandLocaleKeysObject>>(locale: SupportedLocales, path: `command:${K}`): string;
+  get(locale: SupportedLocales, path: `commandDescriptions:${CommandDescriptionsKeys}`): string;
+  get(locale: SupportedLocales, path: `commandCategories:${CommandCategoriesKeys}`): string;
+  get(locale: SupportedLocales, path: `commandNames:${CommandNamesKeys}`): string;
+  get(locale: SupportedLocales, path: `permissions:${PermissionLocaleKeys}`): string;
+  get(lang: SupportedLocales, path: string, ...args: unknown[]) {
     const [category, key] = path.split(':');
     if (!this.cache[category]) return `!!{${category}.${key}}!!`;
 

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -1,5 +1,6 @@
 import type { Awaitable, ChatInputApplicationCommandData, ChatInputCommandInteraction, PermissionResolvable } from 'discord.js';
-import type { AllLocalePaths, CommandCategoriesKeys, CommandNamesKeys } from '../bot/managers/LanguageManager';
+import type { FunctionKeys, NonFunctionKeys } from 'utility-types';
+import type { CommandCategoriesKeys, CommandDescriptionsKeys, CommandLocaleKeysObject, CommandLocaleKeysObjectGeneric, CommandNamesKeys, PermissionLocaleKeys } from '../bot/managers/LanguageManager';
 import type { DenkyClient } from '../types/Client';
 
 class Command {
@@ -49,8 +50,18 @@ class Command {
   }
 }
 
-export type CommandLocale = (path: AllLocalePaths, ...args: unknown[]) => string;
+function t<K extends FunctionKeys<CommandLocaleKeysObject>>(path: `command:${K}`, ...rest: Parameters<CommandLocaleKeysObjectGeneric<K>>): string;
+function t<K extends NonFunctionKeys<CommandLocaleKeysObject>>(path: `command:${K}`): string;
+function t(path: `commandDescriptions:${CommandDescriptionsKeys}`): string;
+function t(path: `commandCategories:${CommandCategoriesKeys}`): string;
+function t(path: `commandNames:${CommandNamesKeys}`): string;
+function t(path: `permissions:${PermissionLocaleKeys}`): string;
 
-export type CommandRunOptions = { t: CommandLocale; interaction: ChatInputCommandInteraction };
+function t(path: string, ...rest: unknown[]) {
+  return `${path}${rest}`;
+}
+
+export type CommandLocale = typeof t;
+export type CommandRunOptions = { t: typeof t; interaction: ChatInputCommandInteraction };
 
 export { Command };


### PR DESCRIPTION
This Pull Request aims to improve types for translate functions (`client.languages.manager.get(locale, key, ?args)`).

In the actual implementation, the key **command:ban/complete** requires 2 parameters. If a developer tries to use this key without providing any argument, no error is thrown and the developer will only know about the error after testing the command.

The changes in this PR are incomplete and not tested yet. The improved types are only available on **CommandLocale** (`t('key')`) & **LanguageManager**.

TODO: pin dependencies