### PR TITLE
refactor: improve locale types

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -41,7 +41,8 @@
     "prisma-redis-middleware": "4.0.6",
     "tslib": "workspace:^",
     "undici": "5.7.0",
-    "utf-8-validate": "5.0.9"
+    "utf-8-validate": "5.0.9",
+    "utility-types": "3.10.0"
   },
   "optionalDependencies": {
     "erlpack": "0.1.4",

--- a/packages/bot/src/commands/Configuration/_config_suggestions.ts
+++ b/packages/bot/src/commands/Configuration/_config_suggestions.ts
@@ -72,6 +72,7 @@ export default class SuggestionsSubCommand extends Command {
     });
 
     collector.on('collect', async int => {
+      if (!interaction.channel) return;
       let updatedConfig = (await this.client.databases.getSuggestion(interaction.guild.id)) as Suggestion;
       await int.deferUpdate();
       if (int.isSelectMenu()) {

--- a/packages/bot/src/commands/Information/_server_banner.ts
+++ b/packages/bot/src/commands/Information/_server_banner.ts
@@ -30,7 +30,7 @@ export default class ServerBannerSubCommand extends Command {
       return;
     }
 
-    const embed = new EmbedBuilder().setColor('Blurple').setTitle(t('command:server/banner/title')).setImage(guildBanner);
+    const embed = new EmbedBuilder().setColor('Blurple').setTitle(t('command:server/banner/title', interaction.guild.name)).setImage(guildBanner);
 
     const button = new ButtonBuilder().setURL(guildBanner).setStyle(ButtonStyle.Link).setLabel(t('command:server/banner/browser'));
 

--- a/packages/bot/src/commands/Information/_server_info.ts
+++ b/packages/bot/src/commands/Information/_server_info.ts
@@ -61,7 +61,7 @@ export default class ServerInfoSubCommand extends Command {
         },
         {
           name: 'Boosts',
-          value: t('command:server/info/embed/boosts', interaction.guild.premiumSubscriptionCount, interaction.guild.premiumTier),
+          value: t('command:server/info/embed/boosts', interaction.guild.premiumSubscriptionCount ?? 0, interaction.guild.premiumTier),
           inline: true
         }
       ])

--- a/packages/bot/src/commands/Utils/suggestion.ts
+++ b/packages/bot/src/commands/Utils/suggestion.ts
@@ -175,7 +175,7 @@ export default class PingCommand extends Command {
         const noticeEmbed = new EmbedBuilder()
           .setColor('Red')
           .setTimestamp()
-          .setDescription(`❌ **|** ${t('command:suggestions/management/deny/memberdm', embed.data.description?.replace('> ', '').slice(0, 15), interaction.user, suggestionMessage.url)}`);
+          .setDescription(`❌ **|** ${t('command:suggestions/management/deny/memberdm', embed.data.description?.replace('> ', '').slice(0, 15) ?? '', interaction.user, suggestionMessage.url)}`);
         interaction.guild.members
           .fetch(suggesterId)
           .then(m => {
@@ -302,7 +302,7 @@ export default class PingCommand extends Command {
         const noticeEmbed = new EmbedBuilder()
           .setColor('Green')
           .setTimestamp()
-          .setDescription(`✅ **|** ${t('command:suggestions/management/accept/memberdm', embed.data.description?.replace('> ', '').slice(0, 15), interaction.user, suggestionMessage.url)}`);
+          .setDescription(`✅ **|** ${t('command:suggestions/management/accept/memberdm', embed.data.description?.replace('> ', '').slice(0, 15) ?? '', interaction.user, suggestionMessage.url)}`);
         interaction.guild.members
           .fetch(suggesterId)
           .then(m => {

--- a/packages/bot/src/events/interactionCreate.ts
+++ b/packages/bot/src/events/interactionCreate.ts
@@ -1,6 +1,5 @@
 import { ChannelType, ChatInputCommandInteraction, EmbedBuilder, Interaction, PermissionsBitField, TextChannel, WebhookClient } from 'discord.js';
 import { recommendLocale } from '../helpers/Locale';
-import type { AllLocalePaths } from '../lib/managers/LanguageManager';
 import type { Command, CommandLocale, CommandRunOptions } from '../structures/Command';
 import { Event } from '../structures/Event';
 import type { DenkyClient } from '../types/Client';
@@ -21,7 +20,7 @@ export default class InteractionCreateEvent extends Event {
 
     const userLocale = recommendLocale(interaction.locale);
 
-    const t = (path: AllLocalePaths, ...args: unknown[]) => {
+    const t: CommandLocale = (path: Parameters<CommandLocale>[0], ...args: any) => {
       return client.languages.manager.get(userLocale, path, ...args);
     };
 

--- a/packages/bot/src/events/messageCreate.ts
+++ b/packages/bot/src/events/messageCreate.ts
@@ -1,8 +1,8 @@
 import type { Message } from 'discord.js';
+import { recommendLocale } from '../helpers/Locale';
+import type { CommandLocale } from '../structures/Command';
 import { Event } from '../structures/Event';
 import type { DenkyClient } from '../types/Client';
-import { recommendLocale } from '../helpers/Locale';
-import type { AllLocalePaths } from '../lib/managers/LanguageManager';
 
 export default class MessageCreateEvent extends Event {
   constructor() {
@@ -21,7 +21,7 @@ export default class MessageCreateEvent extends Event {
     const data = await client.databases.getAfk(message.author.id);
     if (!data) return;
 
-    const t = (path: AllLocalePaths, ...args: unknown[]) => {
+    const t: CommandLocale = (path: Parameters<CommandLocale>[0], ...args: any) => {
       return client.languages.manager.get(recommendLocale(message.guild?.preferredLocale), path, ...args);
     };
 
@@ -35,7 +35,7 @@ export default class MessageCreateEvent extends Event {
   async verifyAFKMention(client: DenkyClient, message: Message) {
     if (message.mentions.users.size === 0) return;
 
-    const t = (path: AllLocalePaths, ...args: unknown[]) => {
+    const t: CommandLocale = (path: Parameters<CommandLocale>[0], ...args: any) => {
       return client.languages.manager.get(recommendLocale(message.guild?.preferredLocale), path, ...args);
     };
 

--- a/packages/bot/src/events/messageCreate.ts
+++ b/packages/bot/src/events/messageCreate.ts
@@ -45,7 +45,7 @@ export default class MessageCreateEvent extends Event {
       if (!data) return;
       message
         .reply({
-          content: t('command:afk/mentioned', user, data.startTime, data.reason),
+          content: t('command:afk/mentioned', user, data.startTime, data.reason ?? undefined),
           allowedMentions: {
             parse: [],
             users: [message.author.id]

--- a/packages/bot/src/lib/managers/LanguageManager.ts
+++ b/packages/bot/src/lib/managers/LanguageManager.ts
@@ -20,12 +20,6 @@ export type CommandCategoriesKeys = keyof CommandCategoriesKeysObject;
 export type PermissionLocaleKeys = keyof PermissionLocaleKeysObject;
 
 type AllLocaleKeys = CommandLocaleKeys | CommandNamesKeys | CommandDescriptionsKeys | CommandCategoriesKeys | PermissionLocaleKeys;
-export type AllLocalePaths =
-  | `command:${CommandLocaleKeys}`
-  | `commandDescriptions:${CommandDescriptionsKeys}`
-  | `commandCategories:${CommandCategoriesKeys}`
-  | `commandNames:${CommandNamesKeys}`
-  | `permissions:${PermissionLocaleKeys}`;
 
 type CommandLocaleKeysObjectGeneric<K extends FunctionKeys<CommandLocaleKeysObject>> = CommandLocaleKeysObject[K];
 

--- a/packages/bot/src/lib/managers/LanguageManager.ts
+++ b/packages/bot/src/lib/managers/LanguageManager.ts
@@ -73,13 +73,13 @@ export class LanguageManager {
   }
 }
 
-export function translateTuple<K extends FunctionKeys<CommandLocaleKeysObject>>(...args: [path: `command:${K}`, ...args: Parameters<CommandLocaleKeysObjectGeneric<K>>]): string;
-export function translateTuple<K extends NonFunctionKeys<CommandLocaleKeysObject>>(...args: [path: `command:${K}`]): string;
-export function translateTuple(...args: [path: `commandDescriptions:${CommandDescriptionsKeys}`]): string;
-export function translateTuple(...args: [path: `commandCategories:${CommandCategoriesKeys}`]): string;
-export function translateTuple(...args: [path: `commandNames:${CommandNamesKeys}`]): string;
-export function translateTuple(...args: [path: `permissions:${PermissionLocaleKeys}`]): string;
-export function translateTuple(...args: [path: never]): string;
-export function translateTuple(args: never): never {
+export function translateTuple<K extends FunctionKeys<CommandLocaleKeysObject>>(...path: [path: `command:${K}`, ...args: Parameters<CommandLocaleKeysObjectGeneric<K>>]): string;
+export function translateTuple<K extends NonFunctionKeys<CommandLocaleKeysObject>>(...path: [path: `command:${K}`]): string;
+export function translateTuple(...path: [path: `commandDescriptions:${CommandDescriptionsKeys}`]): string;
+export function translateTuple(...path: [path: `commandCategories:${CommandCategoriesKeys}`]): string;
+export function translateTuple(...path: [path: `commandNames:${CommandNamesKeys}`]): string;
+export function translateTuple(...path: [path: `permissions:${PermissionLocaleKeys}`]): string;
+export function translateTuple(...path: ['Unknown key.' | 'Chave desconhecida.']): string;
+export function translateTuple(...args: never): string {
   return args;
 }

--- a/packages/bot/src/lib/managers/LanguageManager.ts
+++ b/packages/bot/src/lib/managers/LanguageManager.ts
@@ -79,7 +79,7 @@ export function translateTuple(...path: [path: `commandDescriptions:${CommandDes
 export function translateTuple(...path: [path: `commandCategories:${CommandCategoriesKeys}`]): string;
 export function translateTuple(...path: [path: `commandNames:${CommandNamesKeys}`]): string;
 export function translateTuple(...path: [path: `permissions:${PermissionLocaleKeys}`]): string;
-export function translateTuple(...path: ['Unknown key.' | 'Chave desconhecida.']): string;
+export function translateTuple(...path: [path: never]): string;
 export function translateTuple(...args: never): string {
   return args;
 }

--- a/packages/bot/src/structures/Command.ts
+++ b/packages/bot/src/structures/Command.ts
@@ -1,5 +1,5 @@
 import type { Awaitable, ChatInputApplicationCommandData, ChatInputCommandInteraction, PermissionResolvable } from 'discord.js';
-import type { AllLocalePaths, CommandCategoriesKeys, CommandNamesKeys } from '../lib/managers/LanguageManager';
+import type { translateTuple, CommandCategoriesKeys, CommandNamesKeys } from '../lib/managers/LanguageManager';
 import type { DenkyClient } from '../types/Client';
 
 class Command {
@@ -49,7 +49,7 @@ class Command {
   }
 }
 
-export type CommandLocale = (path: AllLocalePaths, ...args: unknown[]) => string;
+export type CommandLocale = typeof translateTuple;
 export type CommandRunOptions = { t: CommandLocale; interaction: ChatInputCommandInteraction };
 
 export { Command };

--- a/packages/locales/assets/command/en_US/index.ts
+++ b/packages/locales/assets/command/en_US/index.ts
@@ -1,4 +1,4 @@
-import type { Guild, GuildMember, TextChannel, User } from 'discord.js';
+import type { Guild, GuildMember, GuildTextBasedChannel, User } from 'discord.js';
 
 export default {
   // General errors
@@ -27,8 +27,8 @@ export default {
   'help/button/add': 'Add me',
   'help/button/support': 'Support Server',
   'help/button/vote': 'Vote',
-  'help/embed/description': (supportClick: string, addClick: string, totalCommands: number) =>
-    `❔ My prefix on this server is: \`/\`.\n🚪 Join my support server: [click here](${supportClick}).\n🎉 Add me to your server: [click here](${addClick}).\n\nCurrently I have \`${totalCommands}\` commands.`,
+  'help/embed/description': (support: string, add: string, totalCommands: number) =>
+    `❔ My prefix on this server is: \`/\`.\n🚪 Join my support server: [click here](${support}).\n🎉 Add me to your server: [click here](${add}).\n\nCurrently I have \`${totalCommands}\` commands.`,
   'help/menu/placeholder': 'Click here to choose the command category.',
   'help/warn/guildonly-commands': '⚠️ **|** Some commands may be restricted to run only on servers and are therefore not available here.',
 
@@ -39,18 +39,18 @@ export default {
   'user/info/memberJoinedAt': 'Member joined at',
 
   // User avatar
-  'user/avatar/title': (user: User) => `${user}'s avatar`,
+  'user/avatar/title': (user: string) => `${user}'s avatar`,
   'user/avatar/browser': 'Open in browser',
   'user/avatar/seeGuildAvatar': 'See guild avatar',
   'user/avatar/seeGlobalAvatar': 'See global avatar',
 
   // User Banner
   'user/banner/noBanner': 'This user no  has banner.',
-  'user/banner/title': (user: User) => `${user}'s banner`,
+  'user/banner/title': (user: string) => `${user}'s banner`,
   'user/banner/browser': 'Open in browser',
 
   // Server icon
-  'server/icon/title': (guild: Guild) => `${guild} icon`,
+  'server/icon/title': (guild: string) => `${guild} icon`,
   'server/icon/browser': 'Open in browser',
   'server/icon/noIcon': 'This server no has icon.',
 
@@ -122,11 +122,11 @@ export default {
 
   'config/suggestions/actions/enabled': 'The suggestion system has been successfully enabled! Now, you need to add categories to finish the process.',
 
-  'config/suggestions/actions/category/askToAdd': (channel: TextChannel) => `Send a message mentioning a channel to add it to the category list. Example: ${channel}`,
+  'config/suggestions/actions/category/askToAdd': (channel: GuildTextBasedChannel) => `Send a message mentioning a channel to add it to the category list. Example: ${channel}`,
   'config/suggestions/actions/category/added': 'Category added successfully!',
   'config/suggestions/actions/category/addError': "Unable to add category because you didn't send a message mentioning a channel!",
 
-  'config/suggestions/actions/category/askToRemove': (channel: TextChannel) => `Send a message mentioning a channel to remove it from the category list. Example: ${channel}`,
+  'config/suggestions/actions/category/askToRemove': (channel: GuildTextBasedChannel) => `Send a message mentioning a channel to remove it from the category list. Example: ${channel}`,
   'config/suggestions/actions/category/removed': 'Category removed successfully!',
   'config/suggestions/actions/category/delError': "Unable to remove category because you didn't send a message mentioning a channel!",
 
@@ -141,7 +141,7 @@ export default {
 
   // Server Banner
   'server/banner/noBanner': 'This server no has banner.',
-  'server/banner/title': (guild: Guild) => `${guild} banner`,
+  'server/banner/title': (guild: string) => `${guild} banner`,
   'server/banner/browser': 'Open in browser',
 
   // Suggestions

--- a/packages/locales/assets/command/pt_BR/index.ts
+++ b/packages/locales/assets/command/pt_BR/index.ts
@@ -1,4 +1,4 @@
-import type { Guild, GuildMember, TextChannel, User } from 'discord.js';
+import type { Guild, GuildMember, GuildTextBasedChannel, User } from 'discord.js';
 
 export default {
   // General errors
@@ -27,8 +27,8 @@ export default {
   'help/button/add': 'Ne adicione',
   'help/button/support': 'Servidor de Suporte',
   'help/button/vote': 'Vote',
-  'help/embed/description': (supportClick: string, addClick: string, totalCommands: string) =>
-    `❔ Meu prefixo neste servidor é: \`/.\`\n🚪 Entre em meu servidor de suporte: [clique aqui](${supportClick}).\n🎉 Me adicione em seu servidor: [clique aqui](${addClick}).\n\nAtualmente eu possuo \`${totalCommands}\` comandos.`,
+  'help/embed/description': (support: string, add: string, totalCommands: number) =>
+    `❔ Meu prefixo neste servidor é: \`/.\`\n🚪 Entre em meu servidor de suporte: [clique aqui](${support}).\n🎉 Me adicione em seu servidor: [clique aqui](${add}).\n\nAtualmente eu possuo \`${totalCommands}\` comandos.`,
   'help/menu/placeholder': 'Clique aqui para escolher a categoria de comandos.',
   'help/warn/guildonly-commands': '⚠️ **|** Alguns comandos podem estar restringidos para serem executados apenas em servidores e por isso não estão disponíveis aqui.',
 
@@ -39,18 +39,18 @@ export default {
   'user/info/memberJoinedAt': 'Entrou em',
 
   // User avatar
-  'user/avatar/title': (user: User) => `Avatar de ${user}`,
+  'user/avatar/title': (user: string) => `Avatar de ${user}`,
   'user/avatar/browser': 'Abrir avatar no navegador',
   'user/avatar/seeGuildAvatar': 'Ver o avatar do usuário neste servidor',
   'user/avatar/seeGlobalAvatar': 'Ver o avatar do usuário neste servidor',
 
   // User Banner
   'user/banner/noBanner': 'Este usuário não tem um banner.',
-  'user/banner/title': (user: User) => `Banner de ${user}`,
+  'user/banner/title': (user: string) => `Banner de ${user}`,
   'user/banner/browser': 'Abrir banner no navegador',
 
   // Server icon
-  'server/icon/title': (guild: Guild) => `Ícone do servidor ${guild}`,
+  'server/icon/title': (guild: string) => `Ícone do servidor ${guild}`,
   'server/icon/browser': 'Abrir ícone no navegador',
   'server/icon/noIcon': 'Este servidor não tem um ícone.',
 
@@ -122,11 +122,11 @@ export default {
 
   'config/suggestions/actions/enabled': 'O sistema de sugestões foi habilitado com sucesso! Agora, você precisa adicionar categorias para finalizar o processo.',
 
-  'config/suggestions/actions/category/askToAdd': (channel: TextChannel) => `Envie uma mensagem mencionando um canal para o adicionar a lista de categorias. Exemplo: ${channel}`,
+  'config/suggestions/actions/category/askToAdd': (channel: GuildTextBasedChannel) => `Envie uma mensagem mencionando um canal para o adicionar a lista de categorias. Exemplo: ${channel}`,
   'config/suggestions/actions/category/added': 'Categoria adicionada com sucesso!',
   'config/suggestions/actions/category/addError': 'Não foi possível adicionar a categoria pois você não enviou uma mensagem mencionando um canal!',
 
-  'config/suggestions/actions/category/askToRemove': (channel: TextChannel) => `Envie uma mensagem mencionando um canal para o remover da lista de categorias. Exemplo: ${channel}`,
+  'config/suggestions/actions/category/askToRemove': (channel: GuildTextBasedChannel) => `Envie uma mensagem mencionando um canal para o remover da lista de categorias. Exemplo: ${channel}`,
   'config/suggestions/actions/category/removed': 'Categoria removida com sucesso!',
   'config/suggestions/actions/category/delError': 'Não foi possível remover a categoria pois você não enviou uma mensagem mencionando um canal!',
 
@@ -144,7 +144,7 @@ export default {
 
   // Server Banner
   'server/banner/noBanner': 'Este servidor não tem um banner.',
-  'server/banner/title': (guild: Guild) => `Banner do servidor ${guild}`,
+  'server/banner/title': (guild: string) => `Banner do servidor ${guild}`,
   'server/banner/browser': 'Abrir banner no navegador',
 
   // Suggestions

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,6 +2346,11 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+utility-types@3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
Continuation of https://github.com/denkylabs/denkybot/pull/85

This Pull Request aims to improve types for translate functions (`client.languages.manager.get(locale, key, ?args)`, `t(key, ?args`) 

For example, in the actual implementation, the key `command:ban/complete` requires 2 parameters. If a developer tries to use this key without providing any argument, no error is thrown and the developer will only know about the error after testing the command.